### PR TITLE
Bump DigitalOcean to use Terraform V1.22.2 + Valid configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
-/*cloud-proxy is a utility for creating multiple instances
-and starting socks proxies via SSH after creation.*/
+/*
+cloud-proxy is a utility for creating multiple instances
+and starting socks proxies via SSH after creation.
+*/
 package main
 
 import (
@@ -219,7 +221,7 @@ func createTunnels(computerUsers map[string]string) []*os.Process {
 		if len(splitOutput) != 2 {
 			continue
 		}
-		ip := strings.TrimSpace(splitOutput[1])
+		ip := strings.Trim(strings.TrimSpace(splitOutput[1]), "\"")
 		computerName := strings.TrimSpace(splitOutput[0])
 		port := fmt.Sprintf("%d", *startPort)
 		var host string

--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func createTerraformFile(fileName, templateData string, data interface{}) {
 }
 
 func createTunnels(computerUsers map[string]string) []*os.Process {
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	output, err := exec.Command("terraform", "output").Output()
 	if err != nil {
 		log.Fatal(err)
@@ -229,7 +229,7 @@ func createTunnels(computerUsers map[string]string) []*os.Process {
 			host = fmt.Sprintf("%s@%s", user, ip)
 		}
 		fmt.Printf("creating tunnel to %s on %s\n", host, port)
-		cmd := exec.Command("ssh", "-D", port, "-N", "-o", "StrictHostKeyChecking=no", "-i", *sshLocation, host)
+		cmd := exec.Command("ssh", "-D", port, "-N", "-o", "StrictHostKeyChecking=no", "-o", "ServerAliveInterval=30", "-i", *sshLocation, host)
 		cmd.Stderr = os.Stderr
 		cmd.Start()
 		tunnelProcesses = append(tunnelProcesses, cmd.Process)

--- a/regions.go
+++ b/regions.go
@@ -3,7 +3,7 @@ package main
 var doRegions = []string{
 	"nyc1",
 	"nyc3",
-	"sfo2",
+	"sfo3",
 	"ams3",
 	"sgp1",
 	"lon1",

--- a/templates.go
+++ b/templates.go
@@ -1,7 +1,17 @@
 package main
 
 var doTemplate = `
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "1.22.2"
+    }
+  }
+}
+
 variable "do_token" {}
+variable "pvt_key" {}
 variable "do_ssh_fingerprint" {}
 
 provider "digitalocean" {
@@ -10,17 +20,25 @@ provider "digitalocean" {
 
 {{range .}}
 resource "digitalocean_droplet" "{{.Name}}" {
-  image  = "ubuntu-14-04-x64"
-  name   = "{{.Name}}"
+  image = "ubuntu-22-04-x64"
+  name = "{{.Name}}"
   region = "{{.Region}}"
-  size   = "512mb"
+  size = "s-1vcpu-1gb"
+  private_networking = true
   ssh_keys = [
     "${var.do_ssh_fingerprint}"
   ]
+  connection {
+    host = self.ipv4_address
+    user = "root"
+    type = "ssh"
+    private_key = file("${var.pvt_key}")
+    timeout = "2m"
+  }
 }
 
 output "{{.Name}}-IP" {
-	value = "${digitalocean_droplet.{{.Name}}.ipv4_address}"
+    value = "${digitalocean_droplet.{{.Name}}.ipv4_address}"
 }
 
 {{end}}


### PR DESCRIPTION
Bump DigitalOcean to use Terraform V1.22.2 the current V0.12 is deprecated and unreliable.
Furthermore DigitalOcean image is changed from ubuntu-14-04-x64 to ubuntu-22-04-x64 since it is not supported any more (deprecated).